### PR TITLE
:bug: Use cluster service CIDR in NodeConfig CIDR

### DIFF
--- a/bootstrap/eks/controllers/eksconfig_controller.go
+++ b/bootstrap/eks/controllers/eksconfig_controller.go
@@ -264,6 +264,11 @@ func (r *EKSConfigReconciler) joinWorker(ctx context.Context, cluster *clusterv1
 		return ctrl.Result{}, err
 	}
 
+	serviceCIDR := ""
+	if cluster.Spec.ClusterNetwork != nil && cluster.Spec.ClusterNetwork.Services != nil && len(cluster.Spec.ClusterNetwork.Services.CIDRBlocks) > 0 {
+		serviceCIDR = cluster.Spec.ClusterNetwork.Services.CIDRBlocks[0]
+	}
+
 	// Create unified NodeInput for both AL2 and AL2023
 	nodeInput := &userdata.NodeInput{
 		ClusterName:              controlPlane.Spec.EKSClusterName,
@@ -281,7 +286,7 @@ func (r *EKSConfigReconciler) joinWorker(ctx context.Context, cluster *clusterv1
 		DiskSetup:                config.Spec.DiskSetup,
 		Mounts:                   config.Spec.Mounts,
 		Files:                    files,
-		ClusterCIDR:              controlPlane.Spec.NetworkSpec.VPC.CidrBlock,
+		ServiceCIDR:              serviceCIDR,
 	}
 
 	if config.Spec.PauseContainer != nil {

--- a/bootstrap/eks/internal/userdata/node.go
+++ b/bootstrap/eks/internal/userdata/node.go
@@ -83,7 +83,7 @@ spec:
     name: {{.ClusterName}}
     apiServerEndpoint: {{.APIServerEndpoint}}
     certificateAuthority: {{.CACert}}
-    cidr: {{if .ClusterCIDR}}{{.ClusterCIDR}}{{else}}10.96.0.0/12{{end}}
+    cidr: {{if .ServiceCIDR}}{{.ServiceCIDR}}{{else}}172.20.0.0/16{{end}}
   kubelet:
     config:
       maxPods: {{.MaxPods}}
@@ -130,7 +130,7 @@ type NodeInput struct {
 	Boundary          string
 	CACert            string
 	CapacityType      *v1beta2.ManagedMachinePoolCapacityType
-	ClusterCIDR       string // CIDR range for the cluster
+	ServiceCIDR       string // Service CIDR range for the cluster
 	ClusterDNS        string
 	MaxPods           *int32
 	NodeGroupName     string

--- a/bootstrap/eks/internal/userdata/node_test.go
+++ b/bootstrap/eks/internal/userdata/node_test.go
@@ -450,7 +450,8 @@ EOF`,
 				if !strings.Contains(output, "apiVersion: node.eks.aws/v1alpha1") ||
 					!strings.Contains(output, "name: my-cluster") ||
 					!strings.Contains(output, "apiServerEndpoint: https://example.com") ||
-					!strings.Contains(output, `"--node-labels=app=my-app,environment=production"`) {
+					!strings.Contains(output, `"--node-labels=app=my-app,environment=production"`) ||
+					!strings.Contains(output, "cidr: 172.20.0.0/16") {
 					return false
 				}
 
@@ -493,13 +494,15 @@ func TestGenerateAL2023UserData(t *testing.T) {
 				CACert:            "test-cert",
 				NodeGroupName:     "test-nodegroup",
 				UseMaxPods:        ptr.To[bool](false),
-				DNSClusterIP:      ptr.To[string]("10.96.0.10"),
+				DNSClusterIP:      ptr.To[string]("172.20.0.10"),
 			},
 			expectErr: false,
 			verifyOutput: func(output string) bool {
 				return strings.Contains(output, "name: test-cluster") &&
 					strings.Contains(output, "maxPods: 58") &&
-					strings.Contains(output, "nodegroup=test-nodegroup")
+					strings.Contains(output, "nodegroup=test-nodegroup") &&
+					strings.Contains(output, "cidr: 172.20.0.0/16") &&
+					strings.Contains(output, "clusterDNS:\n      - 172.20.0.10")
 			},
 		},
 		{
@@ -513,7 +516,7 @@ func TestGenerateAL2023UserData(t *testing.T) {
 				UseMaxPods:        ptr.To[bool](true),
 				DNSClusterIP:      ptr.To[string]("10.100.0.10"),
 				AMIImageID:        "ami-123456",
-				ClusterCIDR:       "192.168.0.0/16",
+				ServiceCIDR:       "192.168.0.0/16",
 			},
 			expectErr: false,
 			verifyOutput: func(output string) bool {
@@ -544,7 +547,8 @@ func TestGenerateAL2023UserData(t *testing.T) {
 			verifyOutput: func(output string) bool {
 				return strings.Contains(output, "echo 'pre-bootstrap'") &&
 					strings.Contains(output, "echo 'post-bootstrap'") &&
-					strings.Contains(output, `"--node-labels=app=my-app,environment=production"`)
+					strings.Contains(output, `"--node-labels=app=my-app,environment=production"`) &&
+					strings.Contains(output, "cidr: 172.20.0.0/16")
 			},
 		},
 		{


### PR DESCRIPTION
As per documentation at https://github.com/awslabs/amazon-eks-ami/blob/v20250813/nodeadm/api/v1alpha1/nodeconfig_types.go#L52-L53:

```
// CIDR is your cluster's service CIDR block. This value is used to infer your cluster's DNS address.
CIDR string `json:"cidr,omitempty"`
```

Previously setting it to the VPC CIDR was breaking DNS resolution in pods because they
were expecting CoreDNS at 10.0.0.10 (10th IP in VPC CIDR) rather than the 10th IP in the service CIDR.

Also change the default service CIDR to EKS default of 172.20.0.0/16 as per EKS docs.