### PR TITLE
:sparkles: feat: simplifies bootstrap for EKS clusters using only nodeadm

### DIFF
--- a/bootstrap/eks/api/v1beta1/conversion.go
+++ b/bootstrap/eks/api/v1beta1/conversion.go
@@ -38,9 +38,6 @@ func (r *EKSConfig) ConvertTo(dstRaw conversion.Hub) error {
 		return err
 	}
 
-	if restored.Spec.NodeType != "" {
-		dst.Spec.NodeType = restored.Spec.NodeType
-	}
 	if restored.Spec.PreBootstrapCommands != nil {
 		dst.Spec.PreBootstrapCommands = restored.Spec.PreBootstrapCommands
 	}
@@ -108,9 +105,6 @@ func (r *EKSConfigTemplate) ConvertTo(dstRaw conversion.Hub) error {
 		return err
 	}
 
-	if restored.Spec.Template.Spec.NodeType != "" {
-		dst.Spec.Template.Spec.NodeType = restored.Spec.Template.Spec.NodeType
-	}
 	if restored.Spec.Template.Spec.PreBootstrapCommands != nil {
 		dst.Spec.Template.Spec.PreBootstrapCommands = restored.Spec.Template.Spec.PreBootstrapCommands
 	}

--- a/bootstrap/eks/api/v1beta1/zz_generated.conversion.go
+++ b/bootstrap/eks/api/v1beta1/zz_generated.conversion.go
@@ -222,7 +222,6 @@ func Convert_v1beta1_EKSConfigSpec_To_v1beta2_EKSConfigSpec(in *EKSConfigSpec, o
 }
 
 func autoConvert_v1beta2_EKSConfigSpec_To_v1beta1_EKSConfigSpec(in *v1beta2.EKSConfigSpec, out *EKSConfigSpec, s conversion.Scope) error {
-	// WARNING: in.NodeType requires manual conversion: does not exist in peer-type
 	out.KubeletExtraArgs = *(*map[string]string)(unsafe.Pointer(&in.KubeletExtraArgs))
 	out.ContainerRuntime = (*string)(unsafe.Pointer(in.ContainerRuntime))
 	out.DNSClusterIP = (*string)(unsafe.Pointer(in.DNSClusterIP))

--- a/bootstrap/eks/api/v1beta2/eksconfig_types.go
+++ b/bootstrap/eks/api/v1beta2/eksconfig_types.go
@@ -22,20 +22,8 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
-// NodeType specifies the type of nodeq
-// +kubebuilder:validation:Enum=al2023
-type NodeType string
-
-const (
-	// NodeTypeAL2023 represents the AL2023 node type.
-	NodeTypeAL2023 NodeType = "al2023"
-)
-
 // EKSConfigSpec defines the desired state of Amazon EKS Bootstrap Configuration.
 type EKSConfigSpec struct {
-	// NodeType specifies the type of node (e.g., "al2023")
-	// +optional
-	NodeType NodeType `json:"nodeType,omitempty"`
 	// KubeletExtraArgs passes the specified kubelet args into the Amazon EKS machine bootstrap script
 	// +optional
 	KubeletExtraArgs map[string]string `json:"kubeletExtraArgs,omitempty"`

--- a/bootstrap/eks/controllers/eksconfig_controller.go
+++ b/bootstrap/eks/controllers/eksconfig_controller.go
@@ -40,7 +40,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
-	infrav1beta1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta1"
 	infrav1beta2 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	eksbootstrapv1 "sigs.k8s.io/cluster-api-provider-aws/v2/bootstrap/eks/api/v1beta2"
 	"sigs.k8s.io/cluster-api-provider-aws/v2/bootstrap/eks/internal/userdata"
@@ -350,36 +349,18 @@ func (r *EKSConfigReconciler) joinWorker(ctx context.Context, cluster *clusterv1
 			log.Info("Failed to get AWSManagedMachinePool", "error", err)
 		}
 	case "AWSMachineTemplate":
-		switch configOwner.GetAPIVersion() {
-		case infrav1beta2.GroupVersion.String():
-			awsmt := &infrav1beta2.AWSMachineTemplate{}
-			var awsMTGetErr error
-			if awsMTGetErr = r.Get(ctx, client.ObjectKey{Namespace: config.Namespace, Name: configOwner.GetName()}, awsmt); awsMTGetErr == nil {
-				log.Info("Found AWSMachineTemplate", "name", awsmt.Name)
-				if awsmt.Spec.Template.Spec.AMI.ID != nil {
-					nodeInput.AMIImageID = *awsmt.Spec.Template.Spec.AMI.ID
-					log.Info("Set AMI ID from AWSMachineTemplate", "amiID", nodeInput.AMIImageID)
-				} else {
-					log.Info("No AMI ID found in AWSMachineTemplate")
-				}
-			}
-				log.Info("Failed to get AWSMachineTemplate", "error", awsMTGetErr)
-			}
-		case infrav1beta1.GroupVersion.String():
-			awsmt := &infrav1beta1.AWSMachineTemplate{}
-			var awsMTGetErr error
-			if awsMTGetErr = r.Get(ctx, client.ObjectKey{Namespace: config.Namespace, Name: configOwner.GetName()}, awsmt); awsMTGetErr == nil {
-				log.Info("Found AWSMachineTemplate", "name", awsmt.Name)
-				if awsmt.Spec.Template.Spec.AMI.ID != nil {
-					nodeInput.AMIImageID = *awsmt.Spec.Template.Spec.AMI.ID
-					log.Info("Set AMI ID from AWSMachineTemplate", "amiID", nodeInput.AMIImageID)
-				} else {
-					log.Info("No AMI ID found in AWSMachineTemplate")
-				}
+		awsmt := &infrav1beta2.AWSMachineTemplate{}
+		var awsMTGetErr error
+		if awsMTGetErr = r.Get(ctx, client.ObjectKey{Namespace: config.Namespace, Name: configOwner.GetName()}, awsmt); awsMTGetErr == nil {
+			log.Info("Found AWSMachineTemplate", "name", awsmt.Name)
+			if awsmt.Spec.Template.Spec.AMI.ID != nil {
+				nodeInput.AMIImageID = *awsmt.Spec.Template.Spec.AMI.ID
+				log.Info("Set AMI ID from AWSMachineTemplate", "amiID", nodeInput.AMIImageID)
 			} else {
-				log.Info("Failed to get AWSMachineTemplate", "error", awsMTGetErr)
+				log.Info("No AMI ID found in AWSMachineTemplate")
 			}
 		}
+		log.Info("Failed to get AWSMachineTemplate", "error", awsMTGetErr)
 	default:
 		log.Info("Config owner kind not recognized for AMI extraction", "kind", configOwner.GetKind())
 	}

--- a/bootstrap/eks/internal/userdata/node.go
+++ b/bootstrap/eks/internal/userdata/node.go
@@ -47,7 +47,7 @@ runcmd:
 {{- template "disk_setup" .DiskSetup}}
 {{- template "fs_setup" .DiskSetup}}
 {{- template "mounts" .Mounts}}
---{{.Boundary}}--`
+--{{.Boundary}}`
 
 	// Shell script part template for nodeadm.
 	shellScriptPartTemplate = `
@@ -70,7 +70,7 @@ set -o nounset
 {{.}}
 {{- end}}
 {{- end}}
---{{ .Boundary }}--`
+--{{ .Boundary }}`
 
 	// Node config part template for nodeadm.
 	nodeConfigPartTemplate = `
@@ -101,7 +101,7 @@ spec:
     {{- end }}
     {{- end }}
 
---{{.Boundary}}--`
+--{{.Boundary}}`
 
 	nodeLabelImage        = "eks.amazonaws.com/nodegroup-image=%s"
 	nodeLabelNodeGroup    = "eks.amazonaws.com/nodegroup=%s"
@@ -216,6 +216,8 @@ func NewNode(input *NodeInput) ([]byte, error) {
 			return nil, fmt.Errorf("failed to execute node user data template: %w", err)
 		}
 	}
+	// write the final boundry closing, all of the ones in the script use intermediate boundries
+	buf.Write([]byte("--"))
 	return buf.Bytes(), nil
 
 }

--- a/bootstrap/eks/internal/userdata/node.go
+++ b/bootstrap/eks/internal/userdata/node.go
@@ -34,11 +34,6 @@ const (
 	defaultBootstrapCommand = "/etc/eks/bootstrap.sh"
 	boundary                = "//"
 
-	// AMIFamilyAL2 is the Amazon Linux 2 AMI family.
-	AMIFamilyAL2 = "AmazonLinux2"
-	// AMIFamilyAL2023 is the Amazon Linux 2023 AMI family.
-	AMIFamilyAL2023 = "AmazonLinux2023"
-
 	nodeUserData = `#cloud-config
 {{template "files" .Files}}
 runcmd:
@@ -52,7 +47,7 @@ runcmd:
 {{- template "mounts" .Mounts}}
 `
 
-	// Shell script part template for AL2023.
+	// Shell script part template for nodeadm.
 	shellScriptPartTemplate = `--{{.Boundary}}
 Content-Type: text/x-shellscript; charset="us-ascii"
 
@@ -70,7 +65,7 @@ set -o nounset
 {{- end}}
 {{- end}}`
 
-	// Node config part template for AL2023.
+	// Node config part template for nodeadm.
 	nodeConfigPartTemplate = `
 --{{.Boundary}}
 Content-Type: application/node.eks.aws
@@ -93,8 +88,17 @@ spec:
       {{- end }}
     flags:
     - "--node-labels={{.NodeLabels}}"
+    {{- range $key, $value := .KubeletExtraArgs }}
+    {{- if ne $key "node-labels" }}
+    - "--{{$key}}={{$value}}"
+    {{- end }}
+    {{- end }}
 
 --{{.Boundary}}--`
+
+	nodeLabelImage        = "eks.amazonaws.com/nodegroup-image=%s"
+	nodeLabelNodeGroup    = "eks.amazonaws.com/nodegroup=%s"
+	nodeLabelCapacityType = "eks.amazonaws.com/capacityType=%s"
 )
 
 // NodeInput contains all the information required to generate user data for a node.
@@ -121,10 +125,6 @@ type NodeInput struct {
 	Users                    []eksbootstrapv1.User
 	NTP                      *eksbootstrapv1.NTP
 
-	// AMI Family Type to determine userdata format
-	AMIFamilyType string
-
-	// AL2023 specific fields
 	AMIImageID        string
 	APIServerEndpoint string
 	Boundary          string
@@ -163,71 +163,7 @@ func (ni *NodeInput) BootstrapCommand() string {
 
 // NewNode returns the user data string to be used on a node instance.
 func NewNode(input *NodeInput) ([]byte, error) {
-	// For AL2023, use the multipart MIME format
-	if input.AMIFamilyType == AMIFamilyAL2023 {
-		return generateAL2023UserData(input)
-	}
-
-	// For AL2 and other types, use the standard cloud-config format
-	return generateStandardUserData(input)
-}
-
-// generateStandardUserData generates userdata for AL2 and other standard node types.
-func generateStandardUserData(input *NodeInput) ([]byte, error) {
-	tm := template.New("Node").Funcs(defaultTemplateFuncMap)
-
-	if _, err := tm.Parse(filesTemplate); err != nil {
-		return nil, fmt.Errorf("failed to parse args template: %w", err)
-	}
-
-	if _, err := tm.Parse(argsTemplate); err != nil {
-		return nil, fmt.Errorf("failed to parse args template: %w", err)
-	}
-
-	if _, err := tm.Parse(kubeletArgsTemplate); err != nil {
-		return nil, fmt.Errorf("failed to parse kubeletExtraArgs template: %w", err)
-	}
-
-	if _, err := tm.Parse(commandsTemplate); err != nil {
-		return nil, fmt.Errorf("failed to parse commandsTemplate template: %w", err)
-	}
-
-	if _, err := tm.Parse(ntpTemplate); err != nil {
-		return nil, fmt.Errorf("failed to parse ntp template: %w", err)
-	}
-
-	if _, err := tm.Parse(usersTemplate); err != nil {
-		return nil, fmt.Errorf("failed to parse users template: %w", err)
-	}
-
-	if _, err := tm.Parse(diskSetupTemplate); err != nil {
-		return nil, fmt.Errorf("failed to parse disk setup template: %w", err)
-	}
-
-	if _, err := tm.Parse(fsSetupTemplate); err != nil {
-		return nil, fmt.Errorf("failed to parse fs setup template: %w", err)
-	}
-
-	if _, err := tm.Parse(mountsTemplate); err != nil {
-		return nil, fmt.Errorf("failed to parse mounts template: %w", err)
-	}
-
-	t, err := tm.Parse(nodeUserData)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse Node template: %w", err)
-	}
-
-	var out bytes.Buffer
-	if err := t.Execute(&out, input); err != nil {
-		return nil, fmt.Errorf("failed to generate Node template: %w", err)
-	}
-
-	return out.Bytes(), nil
-}
-
-// generateAL2023UserData generates userdata for Amazon Linux 2023 nodes.
-func generateAL2023UserData(input *NodeInput) ([]byte, error) {
-	if err := validateAL2023Input(input); err != nil {
+	if err := validateNodeInput(input); err != nil {
 		return nil, err
 	}
 
@@ -256,23 +192,24 @@ func generateAL2023UserData(input *NodeInput) ([]byte, error) {
 	}
 
 	return buf.Bytes(), nil
+
 }
 
 // getNodeLabels returns the string representation of node-labels flags for nodeadm.
 func (ni *NodeInput) getNodeLabels() string {
 	if ni.KubeletExtraArgs != nil {
-		if _, ok := ni.KubeletExtraArgs["node-labels"]; ok {
-			return ni.KubeletExtraArgs["node-labels"]
+		if nodeLabelsValue, ok := ni.KubeletExtraArgs["node-labels"]; ok {
+			return nodeLabelsValue
 		}
 	}
 	nodeLabels := make([]string, 0, 3)
 	if ni.AMIImageID != "" {
-		nodeLabels = append(nodeLabels, fmt.Sprintf("eks.amazonaws.com/nodegroup-image=%s", ni.AMIImageID))
+		nodeLabels = append(nodeLabels, fmt.Sprintf(nodeLabelImage, ni.AMIImageID))
 	}
 	if ni.NodeGroupName != "" {
-		nodeLabels = append(nodeLabels, fmt.Sprintf("eks.amazonaws.com/nodegroup=%s", ni.NodeGroupName))
+		nodeLabels = append(nodeLabels, fmt.Sprintf(nodeLabelNodeGroup, ni.NodeGroupName))
 	}
-	nodeLabels = append(nodeLabels, fmt.Sprintf("eks.amazonaws.com/capacityType=%s", ni.getCapacityTypeString()))
+	nodeLabels = append(nodeLabels, fmt.Sprintf(nodeLabelCapacityType, ni.getCapacityTypeString()))
 	return strings.Join(nodeLabels, ",")
 }
 
@@ -291,19 +228,19 @@ func (ni *NodeInput) getCapacityTypeString() string {
 	}
 }
 
-// validateAL2023Input validates the input for AL2023 user data generation.
-func validateAL2023Input(input *NodeInput) error {
+// validateNodeInput validates the input for nodeadm user data generation.
+func validateNodeInput(input *NodeInput) error {
 	if input.APIServerEndpoint == "" {
-		return fmt.Errorf("API server endpoint is required for AL2023")
+		return fmt.Errorf("API server endpoint is required for nodeadm")
 	}
 	if input.CACert == "" {
-		return fmt.Errorf("CA certificate is required for AL2023")
+		return fmt.Errorf("CA certificate is required for nodeadm")
 	}
 	if input.ClusterName == "" {
-		return fmt.Errorf("cluster name is required for AL2023")
+		return fmt.Errorf("cluster name is required for nodeadm")
 	}
 	if input.NodeGroupName == "" {
-		return fmt.Errorf("node group name is required for AL2023")
+		return fmt.Errorf("node group name is required for nodeadm")
 	}
 
 	if input.MaxPods == nil {
@@ -322,7 +259,7 @@ func validateAL2023Input(input *NodeInput) error {
 	}
 	input.NodeLabels = input.getNodeLabels()
 
-	klog.V(2).Infof("AL2023 Userdata Generation - maxPods: %d, node-labels: %s",
+	klog.V(2).Infof("Nodeadm Userdata Generation - maxPods: %d, node-labels: %s",
 		*input.MaxPods, input.NodeLabels)
 
 	return nil

--- a/bootstrap/eks/internal/userdata/node_test.go
+++ b/bootstrap/eks/internal/userdata/node_test.go
@@ -17,378 +17,17 @@ limitations under the License.
 package userdata
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
 	"k8s.io/utils/ptr"
-
-	eksbootstrapv1 "sigs.k8s.io/cluster-api-provider-aws/v2/bootstrap/eks/api/v1beta2"
 )
 
 func TestNewNode(t *testing.T) {
 	format.TruncatedDiff = false
-	g := NewWithT(t)
-
-	type args struct {
-		input *NodeInput
-	}
-
-	tests := []struct {
-		name          string
-		args          args
-		expectedBytes []byte
-		expectErr     bool
-	}{
-		{
-			name: "only cluster name",
-			args: args{
-				input: &NodeInput{
-					ClusterName: "test-cluster",
-				},
-			},
-			expectedBytes: []byte(`#cloud-config
-write_files:
-runcmd:
-  - /etc/eks/bootstrap.sh test-cluster
-`),
-			expectErr: false,
-		},
-		{
-			name: "sample-with-values",
-			args: args{
-				input: &NodeInput{
-					ClusterName: "test-cluster",
-					KubeletExtraArgs: map[string]string{
-						"node-labels":          "node-role.undistro.io/infra=true",
-						"register-with-taints": "dedicated=infra:NoSchedule",
-					},
-				},
-			},
-			expectedBytes: []byte(`#cloud-config
-write_files:
-runcmd:
-  - /etc/eks/bootstrap.sh test-cluster --kubelet-extra-args '--node-labels=node-role.undistro.io/infra=true --register-with-taints=dedicated=infra:NoSchedule'
-`),
-		},
-		{
-			name: "with container runtime",
-			args: args{
-				input: &NodeInput{
-					ClusterName:      "test-cluster",
-					ContainerRuntime: ptr.To[string]("containerd"),
-				},
-			},
-			expectedBytes: []byte(`#cloud-config
-write_files:
-runcmd:
-  - /etc/eks/bootstrap.sh test-cluster --container-runtime containerd
-`),
-		},
-		{
-			name: "with kubelet extra args and container runtime",
-			args: args{
-				input: &NodeInput{
-					ClusterName: "test-cluster",
-					KubeletExtraArgs: map[string]string{
-						"node-labels":          "node-role.undistro.io/infra=true",
-						"register-with-taints": "dedicated=infra:NoSchedule",
-					},
-					ContainerRuntime: ptr.To[string]("containerd"),
-				},
-			},
-			expectedBytes: []byte(`#cloud-config
-write_files:
-runcmd:
-  - /etc/eks/bootstrap.sh test-cluster --kubelet-extra-args '--node-labels=node-role.undistro.io/infra=true --register-with-taints=dedicated=infra:NoSchedule' --container-runtime containerd
-`),
-		},
-		{
-			name: "with ipv6",
-			args: args{
-				input: &NodeInput{
-					ClusterName:     "test-cluster",
-					ServiceIPV6Cidr: ptr.To[string]("fe80:0000:0000:0000:0204:61ff:fe9d:f156/24"),
-					IPFamily:        ptr.To[string]("ipv6"),
-				},
-			},
-			expectedBytes: []byte(`#cloud-config
-write_files:
-runcmd:
-  - /etc/eks/bootstrap.sh test-cluster --ip-family ipv6 --service-ipv6-cidr fe80:0000:0000:0000:0204:61ff:fe9d:f156/24
-`),
-		},
-		{
-			name: "without max pods",
-			args: args{
-				input: &NodeInput{
-					ClusterName: "test-cluster",
-					UseMaxPods:  ptr.To[bool](false),
-				},
-			},
-			expectedBytes: []byte(`#cloud-config
-write_files:
-runcmd:
-  - /etc/eks/bootstrap.sh test-cluster --use-max-pods false
-`),
-		},
-		{
-			name: "with api retry attempts",
-			args: args{
-				input: &NodeInput{
-					ClusterName:      "test-cluster",
-					APIRetryAttempts: ptr.To[int](5),
-				},
-			},
-			expectedBytes: []byte(`#cloud-config
-write_files:
-runcmd:
-  - /etc/eks/bootstrap.sh test-cluster --aws-api-retry-attempts 5
-`),
-		},
-		{
-			name: "with pause container",
-			args: args{
-				input: &NodeInput{
-					ClusterName:           "test-cluster",
-					PauseContainerAccount: ptr.To[string]("12345678"),
-					PauseContainerVersion: ptr.To[string]("v1"),
-				},
-			},
-			expectedBytes: []byte(`#cloud-config
-write_files:
-runcmd:
-  - /etc/eks/bootstrap.sh test-cluster --pause-container-account 12345678 --pause-container-version v1
-`),
-		},
-		{
-			name: "with dns cluster ip",
-			args: args{
-				input: &NodeInput{
-					ClusterName:  "test-cluster",
-					DNSClusterIP: ptr.To[string]("192.168.0.1"),
-				},
-			},
-			expectedBytes: []byte(`#cloud-config
-write_files:
-runcmd:
-  - /etc/eks/bootstrap.sh test-cluster --dns-cluster-ip 192.168.0.1
-`),
-		},
-		{
-			name: "with docker json",
-			args: args{
-				input: &NodeInput{
-					ClusterName:      "test-cluster",
-					DockerConfigJSON: ptr.To[string]("{\"debug\":true}"),
-				},
-			},
-			expectedBytes: []byte(`#cloud-config
-write_files:
-runcmd:
-  - /etc/eks/bootstrap.sh test-cluster --docker-config-json '{"debug":true}'
-`),
-		},
-		{
-			name: "with pre-bootstrap command",
-			args: args{
-				input: &NodeInput{
-					ClusterName:          "test-cluster",
-					PreBootstrapCommands: []string{"date", "echo \"testing\""},
-				},
-			},
-			expectedBytes: []byte(`#cloud-config
-write_files:
-runcmd:
-  - "date"
-  - "echo \"testing\""
-  - /etc/eks/bootstrap.sh test-cluster
-`),
-		},
-		{
-			name: "with post-bootstrap command",
-			args: args{
-				input: &NodeInput{
-					ClusterName:           "test-cluster",
-					PostBootstrapCommands: []string{"date", "echo \"testing\""},
-				},
-			},
-			expectedBytes: []byte(`#cloud-config
-write_files:
-runcmd:
-  - /etc/eks/bootstrap.sh test-cluster
-  - "date"
-  - "echo \"testing\""
-`),
-		},
-		{
-			name: "with pre & post-bootstrap command",
-			args: args{
-				input: &NodeInput{
-					ClusterName:           "test-cluster",
-					PreBootstrapCommands:  []string{"echo \"testing pre\""},
-					PostBootstrapCommands: []string{"echo \"testing post\""},
-				},
-			},
-			expectedBytes: []byte(`#cloud-config
-write_files:
-runcmd:
-  - "echo \"testing pre\""
-  - /etc/eks/bootstrap.sh test-cluster
-  - "echo \"testing post\""
-`),
-		},
-		{
-			name: "with bootstrap override command",
-			args: args{
-				input: &NodeInput{
-					ClusterName:              "test-cluster",
-					BootstrapCommandOverride: ptr.To[string]("/custom/mybootstrap.sh"),
-				},
-			},
-			expectedBytes: []byte(`#cloud-config
-write_files:
-runcmd:
-  - /custom/mybootstrap.sh test-cluster
-`),
-		},
-		{
-			name: "with disk setup and mount points",
-			args: args{
-				input: &NodeInput{
-					ClusterName: "test-cluster",
-					DiskSetup: &eksbootstrapv1.DiskSetup{
-						Filesystems: []eksbootstrapv1.Filesystem{
-							{
-								Device:     "/dev/sdb",
-								Filesystem: "ext4",
-								Label:      "vol2",
-							},
-						},
-						Partitions: []eksbootstrapv1.Partition{
-							{
-								Device: "/dev/sdb",
-								Layout: true,
-							},
-						},
-					},
-					Mounts: []eksbootstrapv1.MountPoints{
-						[]string{"LABEL=vol2", "/mnt/vol2", "ext4", "defaults"},
-						[]string{"LABEL=vol2", "/opt/data", "ext4", "defaults"},
-					},
-				},
-			},
-			expectedBytes: []byte(`#cloud-config
-write_files:
-runcmd:
-  - /etc/eks/bootstrap.sh test-cluster
-disk_setup:
-  /dev/sdb:
-    layout: true
-fs_setup:
-  - label: vol2
-    filesystem: ext4
-    device: /dev/sdb
-mounts:
-  -
-    - LABEL=vol2
-    - /mnt/vol2
-    - ext4
-    - defaults
-  -
-    - LABEL=vol2
-    - /opt/data
-    - ext4
-    - defaults
-`),
-		},
-		{
-			name: "with files",
-			args: args{
-				input: &NodeInput{
-					ClusterName: "test-cluster",
-					Files: []eksbootstrapv1.File{
-						{
-							Path:    "/etc/sysctl.d/91-fs-inotify.conf",
-							Content: "fs.inotify.max_user_instances=256",
-						},
-					},
-				},
-			},
-			expectedBytes: []byte(`#cloud-config
-write_files:
-  - path: /etc/sysctl.d/91-fs-inotify.conf
-    content: |
-      fs.inotify.max_user_instances=256
-runcmd:
-  - /etc/eks/bootstrap.sh test-cluster
-`),
-		},
-		{
-			name: "with ntp",
-			args: args{
-				input: &NodeInput{
-					ClusterName: "test-cluster",
-					NTP: &eksbootstrapv1.NTP{
-						Enabled: aws.Bool(true),
-						Servers: []string{"time1.google.com", "time2.google.com", "time3.google.com", "time4.google.com"},
-					},
-				},
-			},
-			expectedBytes: []byte(`#cloud-config
-write_files:
-runcmd:
-  - /etc/eks/bootstrap.sh test-cluster
-ntp:
-  enabled: true
-  servers:
-    - time1.google.com
-    - time2.google.com
-    - time3.google.com
-    - time4.google.com
-`),
-		},
-		{
-			name: "with users",
-			args: args{
-				input: &NodeInput{
-					ClusterName: "test-cluster",
-					Users: []eksbootstrapv1.User{
-						{
-							Name:  "testuser",
-							Shell: aws.String("/bin/bash"),
-						},
-					},
-				},
-			},
-			expectedBytes: []byte(`#cloud-config
-write_files:
-runcmd:
-  - /etc/eks/bootstrap.sh test-cluster
-users:
-  - name: testuser
-    shell: /bin/bash
-`),
-		},
-	}
-
-	for _, testcase := range tests {
-		t.Run(testcase.name, func(t *testing.T) {
-			bytes, err := NewNode(testcase.args.input)
-			if testcase.expectErr {
-				g.Expect(err).To(HaveOccurred())
-				return
-			}
-
-			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(string(bytes)).To(Equal(string(testcase.expectedBytes)))
-		})
-	}
-}
-
-func TestNewNodeAL2023(t *testing.T) {
 	g := NewWithT(t)
 
 	type args struct {
@@ -402,61 +41,158 @@ func TestNewNodeAL2023(t *testing.T) {
 		verifyOutput func(output string) bool
 	}{
 		{
-			name: "AL2023 with shell script and node config",
+			name: "basic nodeadm userdata",
 			args: args{
 				input: &NodeInput{
-					AMIFamilyType:     AMIFamilyAL2023,
-					ClusterName:       "my-cluster",
+					ClusterName:       "test-cluster",
 					APIServerEndpoint: "https://example.com",
-					CACert:            "Y2VydGlmaWNhdGVBdXRob3JpdHk=",
+					CACert:            "test-ca-cert",
 					NodeGroupName:     "test-nodegroup",
-					DNSClusterIP:      ptr.To[string]("10.100.0.10"),
-					Boundary:          "BOUNDARY",
+				},
+			},
+			expectErr: false,
+			verifyOutput: func(output string) bool {
+				return strings.Contains(output, "MIME-Version: 1.0") &&
+					strings.Contains(output, "name: test-cluster") &&
+					strings.Contains(output, "apiServerEndpoint: https://example.com") &&
+					strings.Contains(output, "certificateAuthority: test-ca-cert") &&
+					strings.Contains(output, "apiVersion: node.eks.aws/v1alpha1")
+			},
+		},
+		{
+			name: "with kubelet extra args",
+			args: args{
+				input: &NodeInput{
+					ClusterName:       "test-cluster",
+					APIServerEndpoint: "https://example.com",
+					CACert:            "test-ca-cert",
+					NodeGroupName:     "test-nodegroup",
 					KubeletExtraArgs: map[string]string{
-						"node-labels": "app=my-app,environment=production",
-					},
-					PreBootstrapCommands: []string{
-						"# Install additional packages",
-						"yum install -y htop jq iptables-services",
-						"",
-						"# Pre-cache commonly used container images",
-						"nohup docker pull public.ecr.aws/eks-distro/kubernetes/pause:3.2 &",
-						"",
-						"# Configure HTTP proxy if needed",
-						`cat > /etc/profile.d/http-proxy.sh << 'EOF'
-export HTTP_PROXY="http://proxy.example.com:3128"
-export HTTPS_PROXY="http://proxy.example.com:3128"
-export NO_PROXY="localhost,127.0.0.1,169.254.169.254,.internal"
-EOF`,
+						"node-labels":          "node-role.undistro.io/infra=true",
+						"register-with-taints": "dedicated=infra:NoSchedule",
 					},
 				},
 			},
 			expectErr: false,
 			verifyOutput: func(output string) bool {
-				// Verify MIME structure
-				if !strings.Contains(output, "MIME-Version: 1.0") ||
-					!strings.Contains(output, `Content-Type: multipart/mixed; boundary="BOUNDARY"`) {
-					return false
-				}
-
-				// Verify shell script content
-				if !strings.Contains(output, "#!/bin/bash") ||
-					!strings.Contains(output, "yum install -y htop jq iptables-services") ||
-					!strings.Contains(output, "docker pull public.ecr.aws/eks-distro/kubernetes/pause:3.2") {
-					return false
-				}
-
-				// Verify node config content
-				if !strings.Contains(output, "apiVersion: node.eks.aws/v1alpha1") ||
-					!strings.Contains(output, "name: my-cluster") ||
-					!strings.Contains(output, "apiServerEndpoint: https://example.com") ||
-					!strings.Contains(output, `"--node-labels=app=my-app,environment=production"`) ||
-					!strings.Contains(output, "cidr: 172.20.0.0/16") {
-					return false
-				}
-
-				return true
+				fmt.Println(output)
+				return strings.Contains(output, "node-role.undistro.io/infra=true") &&
+					strings.Contains(output, "register-with-taints") &&
+					strings.Contains(output, "apiVersion: node.eks.aws/v1alpha1")
 			},
+		},
+		{
+			name: "with pre and post bootstrap commands",
+			args: args{
+				input: &NodeInput{
+					ClusterName:       "test-cluster",
+					APIServerEndpoint: "https://example.com",
+					CACert:            "test-ca-cert",
+					NodeGroupName:     "test-nodegroup",
+					PreBootstrapCommands: []string{
+						"echo 'pre-bootstrap'",
+						"yum install -y htop",
+					},
+					PostBootstrapCommands: []string{
+						"echo 'post-bootstrap'",
+					},
+				},
+			},
+			expectErr: false,
+			verifyOutput: func(output string) bool {
+				return strings.Contains(output, "echo 'pre-bootstrap'") &&
+					strings.Contains(output, "echo 'post-bootstrap'") &&
+					strings.Contains(output, "yum install -y htop") &&
+					strings.Contains(output, "#!/bin/bash") &&
+					strings.Contains(output, "apiVersion: node.eks.aws/v1alpha1")
+			},
+		},
+		{
+			name: "with custom DNS and AMI",
+			args: args{
+				input: &NodeInput{
+					ClusterName:       "test-cluster",
+					APIServerEndpoint: "https://test-endpoint.eks.amazonaws.com",
+					CACert:            "test-cert",
+					NodeGroupName:     "test-nodegroup",
+					UseMaxPods:        ptr.To[bool](true),
+					DNSClusterIP:      ptr.To[string]("10.100.0.10"),
+					AMIImageID:        "ami-123456",
+					ServiceCIDR:       "192.168.0.0/16",
+				},
+			},
+			expectErr: false,
+			verifyOutput: func(output string) bool {
+				return strings.Contains(output, "cidr: 192.168.0.0/16") &&
+					strings.Contains(output, "maxPods: 110") &&
+					strings.Contains(output, "nodegroup-image=ami-123456") &&
+					strings.Contains(output, "clusterDNS:\n      - 10.100.0.10")
+			},
+		},
+		{
+			name: "with capacity type and custom labels",
+			args: args{
+				input: &NodeInput{
+					ClusterName:       "test-cluster",
+					APIServerEndpoint: "https://test-endpoint.eks.amazonaws.com",
+					CACert:            "test-cert",
+					NodeGroupName:     "test-nodegroup",
+					KubeletExtraArgs: map[string]string{
+						"node-labels": "app=my-app,environment=production",
+					},
+				},
+			},
+			expectErr: false,
+			verifyOutput: func(output string) bool {
+				fmt.Println(output)
+				return strings.Contains(output, `"--node-labels=app=my-app,environment=production"`)
+			},
+		},
+		{
+			name: "missing required fields",
+			args: args{
+				input: &NodeInput{
+					ClusterName: "test-cluster",
+					// Missing APIServerEndpoint, CACert, NodeGroupName
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "missing API server endpoint",
+			args: args{
+				input: &NodeInput{
+					ClusterName:   "test-cluster",
+					CACert:        "test-ca-cert",
+					NodeGroupName: "test-nodegroup",
+					// Missing APIServerEndpoint
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "missing CA certificate",
+			args: args{
+				input: &NodeInput{
+					ClusterName:       "test-cluster",
+					APIServerEndpoint: "https://example.com",
+					NodeGroupName:     "test-nodegroup",
+					// Missing CACert
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "missing node group name",
+			args: args{
+				input: &NodeInput{
+					ClusterName:       "test-cluster",
+					APIServerEndpoint: "https://example.com",
+					CACert:            "test-ca-cert",
+					// Missing NodeGroupName
+				},
+			},
+			expectErr: true,
 		},
 	}
 
@@ -470,109 +206,7 @@ EOF`,
 
 			g.Expect(err).NotTo(HaveOccurred())
 			if testcase.verifyOutput != nil {
-				g.Expect(testcase.verifyOutput(string(bytes))).To(BeTrue(), "Output verification failed")
-			}
-		})
-	}
-}
-
-func TestGenerateAL2023UserData(t *testing.T) {
-	g := NewWithT(t)
-
-	tests := []struct {
-		name         string
-		input        *NodeInput
-		expectErr    bool
-		verifyOutput func(output string) bool
-	}{
-		{
-			name: "valid AL2023 input",
-			input: &NodeInput{
-				AMIFamilyType:     AMIFamilyAL2023,
-				ClusterName:       "test-cluster",
-				APIServerEndpoint: "https://test-endpoint.eks.amazonaws.com",
-				CACert:            "test-cert",
-				NodeGroupName:     "test-nodegroup",
-				UseMaxPods:        ptr.To[bool](false),
-				DNSClusterIP:      ptr.To[string]("172.20.0.10"),
-			},
-			expectErr: false,
-			verifyOutput: func(output string) bool {
-				return strings.Contains(output, "name: test-cluster") &&
-					strings.Contains(output, "maxPods: 58") &&
-					strings.Contains(output, "nodegroup=test-nodegroup") &&
-					strings.Contains(output, "cidr: 172.20.0.0/16") &&
-					strings.Contains(output, "clusterDNS:\n      - 172.20.0.10")
-			},
-		},
-		{
-			name: "AL2023 with custom DNS and AMI",
-			input: &NodeInput{
-				AMIFamilyType:     AMIFamilyAL2023,
-				ClusterName:       "test-cluster",
-				APIServerEndpoint: "https://test-endpoint.eks.amazonaws.com",
-				CACert:            "test-cert",
-				NodeGroupName:     "test-nodegroup",
-				UseMaxPods:        ptr.To[bool](true),
-				DNSClusterIP:      ptr.To[string]("10.100.0.10"),
-				AMIImageID:        "ami-123456",
-				ServiceCIDR:       "192.168.0.0/16",
-			},
-			expectErr: false,
-			verifyOutput: func(output string) bool {
-				return strings.Contains(output, "cidr: 192.168.0.0/16") &&
-					strings.Contains(output, "maxPods: 110") &&
-					strings.Contains(output, "nodegroup-image=ami-123456")
-			},
-		},
-		{
-			name: "AL2023 with custom labels and commands",
-			input: &NodeInput{
-				AMIFamilyType:     AMIFamilyAL2023,
-				ClusterName:       "test-cluster",
-				APIServerEndpoint: "https://test-endpoint.eks.amazonaws.com",
-				CACert:            "test-cert",
-				NodeGroupName:     "test-nodegroup",
-				KubeletExtraArgs: map[string]string{
-					"node-labels": "app=my-app,environment=production",
-				},
-				PreBootstrapCommands: []string{
-					"echo 'pre-bootstrap'",
-				},
-				PostBootstrapCommands: []string{
-					"echo 'post-bootstrap'",
-				},
-			},
-			expectErr: false,
-			verifyOutput: func(output string) bool {
-				return strings.Contains(output, "echo 'pre-bootstrap'") &&
-					strings.Contains(output, "echo 'post-bootstrap'") &&
-					strings.Contains(output, `"--node-labels=app=my-app,environment=production"`) &&
-					strings.Contains(output, "cidr: 172.20.0.0/16")
-			},
-		},
-		{
-			name: "AL2023 missing required fields",
-			input: &NodeInput{
-				AMIFamilyType: AMIFamilyAL2023,
-				ClusterName:   "test-cluster",
-				// Missing APIServerEndpoint, CACert, NodeGroupName
-			},
-			expectErr: true,
-		},
-	}
-
-	for _, testcase := range tests {
-		t.Run(testcase.name, func(t *testing.T) {
-			bytes, err := generateAL2023UserData(testcase.input)
-			if testcase.expectErr {
-				g.Expect(err).To(HaveOccurred())
-				return
-			}
-
-			g.Expect(err).NotTo(HaveOccurred())
-			if testcase.verifyOutput != nil {
-				g.Expect(testcase.verifyOutput(string(bytes))).To(BeTrue(), "Output verification failed")
+				g.Expect(testcase.verifyOutput(string(bytes))).To(BeTrue(), "Output verification failed for: %s", testcase.name)
 			}
 		})
 	}

--- a/config/crd/bases/bootstrap.cluster.x-k8s.io_eksconfigs.yaml
+++ b/config/crd/bases/bootstrap.cluster.x-k8s.io_eksconfigs.yaml
@@ -380,11 +380,6 @@ spec:
                     type: string
                   type: array
                 type: array
-              nodeType:
-                description: NodeType specifies the type of node (e.g., "al2023")
-                enum:
-                - al2023
-                type: string
               ntp:
                 description: NTP specifies NTP configuration
                 properties:

--- a/config/crd/bases/bootstrap.cluster.x-k8s.io_eksconfigtemplates.yaml
+++ b/config/crd/bases/bootstrap.cluster.x-k8s.io_eksconfigtemplates.yaml
@@ -318,11 +318,6 @@ spec:
                             type: string
                           type: array
                         type: array
-                      nodeType:
-                        description: NodeType specifies the type of node (e.g., "al2023")
-                        enum:
-                        - al2023
-                        type: string
                       ntp:
                         description: NTP specifies NTP configuration
                         properties:


### PR DESCRIPTION
- removes NodeType field from API because from what i understand all the bootstrapping will be using `nodeadm`
- changes logic for node-labels to include default labels
- gets AMI ID from AWSMachineTemplates 
- adds cloud-config that configures NTP/Disk Setup/Mounts/Users similar to how this was done for bootstrap.sh
- adds tests 